### PR TITLE
Subnet API. Create VN in Azure before running live tests.

### DIFF
--- a/azurecompute-arm/src/main/java/org/jclouds/azurecomputearm/AzureComputeApi.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecomputearm/AzureComputeApi.java
@@ -39,6 +39,7 @@ import org.jclouds.azurecomputearm.features.TrafficManagerApi;
 import org.jclouds.azurecomputearm.features.VirtualMachineApi;
 import org.jclouds.azurecomputearm.features.VirtualNetworkApi;
 import org.jclouds.azurecomputearm.features.VMImageApi;
+import org.jclouds.azurecomputearm.features.SubnetApi;
 import org.jclouds.rest.annotations.Delegate;
 
 /**
@@ -126,6 +127,16 @@ public interface AzureComputeApi extends Closeable {
     */
    @Delegate
    SubscriptionApi getSubscriptionApi();
+
+   /**
+    * The Subnet API includes operations for managing the subnets in your virtual network.
+    *
+    * @see <a href="https://msdn.microsoft.com/en-us/library/azure/mt163621.aspx">docs</a>
+    */
+   @Delegate
+   SubnetApi getSubnetApi(@PathParam("subscriptionid") String subscriptionid,
+                          @PathParam("resourcegroup") String resourcegroup,
+                          @PathParam("virtualnetwork") String virtualnetwork);
 
    /**
     * The Virtual Network API includes operations for managing the virtual networks in your subscription.

--- a/azurecompute-arm/src/main/java/org/jclouds/azurecomputearm/features/SubnetApi.java
+++ b/azurecompute-arm/src/main/java/org/jclouds/azurecomputearm/features/SubnetApi.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azurecomputearm.features;
+
+import org.jclouds.Fallbacks.EmptyListOnNotFoundOr404;
+import org.jclouds.Fallbacks.NullOnNotFoundOr404;
+import org.jclouds.Fallbacks.VoidOnNotFoundOr404;
+import org.jclouds.azurecomputearm.domain.Subnet;
+import org.jclouds.azurecomputearm.oauth.v2.filters.OAuthFilter;
+import org.jclouds.rest.annotations.Fallback;
+import org.jclouds.rest.annotations.MapBinder;
+import org.jclouds.rest.annotations.PayloadParam;
+import org.jclouds.rest.annotations.QueryParams;
+import org.jclouds.rest.annotations.RequestFilters;
+import org.jclouds.rest.annotations.SelectJson;
+import org.jclouds.rest.binders.BindToJsonPayload;
+
+import javax.inject.Named;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+
+@Path("/subscriptions/{subscriptionid}/resourcegroups/{resourcegroup}/providers/Microsoft.Network/virtualNetworks/{virtualnetwork}")
+
+@QueryParams(keys = "api-version", values = "2015-06-15")
+@RequestFilters(OAuthFilter.class)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface SubnetApi {
+
+   @Named("subnet:list")
+   @Path("subnets")
+   @SelectJson("value")
+   @GET
+   @Fallback(EmptyListOnNotFoundOr404.class)
+   List<Subnet> listSubnets();
+
+   @Named("subnet:create_or_update")
+   @Path("subnets/{subnetname}")
+   @MapBinder(BindToJsonPayload.class)
+   @PUT
+   @Fallback(NullOnNotFoundOr404.class)
+   Subnet createOrUpdateSubnet(@PathParam("subnetname") String subnetName,
+                               @PayloadParam("properties") Subnet.SubnetProperties properties);
+
+   @Named("subnet:get")
+   @Path("subnets/{subnetname}")
+   @GET
+   @Fallback(NullOnNotFoundOr404.class)
+   Subnet getSubnet(@PathParam("subnetname") String subnetname);
+
+   @Named("subnet:delete")
+   @Path("subnets/{subnetname}")
+   @DELETE
+   @Fallback(VoidOnNotFoundOr404.class)
+   void deleteSubnet(@PathParam("subnetname") String subnetname);
+}

--- a/azurecompute-arm/src/test/java/org/jclouds/azurecomputearm/features/SubnetApiLiveTest.java
+++ b/azurecompute-arm/src/test/java/org/jclouds/azurecomputearm/features/SubnetApiLiveTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azurecomputearm.features;
+
+import org.jclouds.azurecomputearm.domain.Subnet;
+
+import org.jclouds.azurecomputearm.domain.VirtualNetwork;
+import org.jclouds.azurecomputearm.internal.BaseAzureComputeApiLiveTest;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertNotNull;
+
+// For now live tests expect that Virtual Network "jclouds-virtual-network-live-test" is already created in Azure
+// using address space 10.2.0.0/16.
+// Make sure you delete the "default" subnet in portal after creating the virtual network.
+
+//mvn -Dtest=SubnetApiLiveTest -Dtest.azurecompute-arm.identity="f....a" -Dtest.azurecompute-arm.subscriptionid="626f67f6-8fd0-xxxx-yyyy-e3ce95f7dfec" -Dtest.azurecompute-arm.resourcegroup="hardcodedgroup" -Dtest.azurecompute-arm.credential="yorupass" -Dtest.azurecompute-arm.endpoint="https://management.azure.com/" -Dtest.jclouds.oauth.resource="https://management.azure.com/" -Dtest.oauth.endpoint="https://login.microsoftonline.com/youraccount.onmicrosoft.com/oauth2/token" test
+@Test(groups = "live", singleThreaded = true)
+public class SubnetApiLiveTest extends BaseAzureComputeApiLiveTest {
+
+    final String subscriptionid =  getSubscriptionId();
+    String resourcegroup;
+
+    @BeforeClass
+    @Override
+    public void setup(){
+        super.setup();
+        resourcegroup = getResourceGroupName();
+
+        // Subnets belong to a virtual network so that needs to be created first
+        // VN will be deleted when resource group is deleted
+        VirtualNetwork vn = getOrCreateVirtualNetwork(VIRTUAL_NETWORK_NAME);
+        assertNotNull(vn);
+    }
+
+    @Test(groups = "live")
+    public void deleteSubnetResourceDoesNotExist() {
+
+        final SubnetApi subnetApi = api.getSubnetApi(subscriptionid, resourcegroup, VIRTUAL_NETWORK_NAME);
+
+        subnetApi.deleteSubnet(DEFAULT_SUBNET_NAME);
+
+        //TODO: need to check that we get "no content" back
+    }
+
+    //mvn -Dtest=VirtualNetworkApiLiveTest#createVirtualNetwork test
+    @Test(groups = "live", dependsOnMethods = "deleteSubnetResourceDoesNotExist")
+    public void createSubnet() {
+
+        final SubnetApi subnetApi = api.getSubnetApi(subscriptionid, resourcegroup, VIRTUAL_NETWORK_NAME);
+
+        //Create properties object
+        //addressPrefix must match Virtual network address space!
+        Subnet.SubnetProperties properties = Subnet.SubnetProperties.builder().addressPrefix(DEFAULT_SUBNET_ADDRESS_SPACE).build();
+
+        Subnet subnet = subnetApi.createOrUpdateSubnet(DEFAULT_SUBNET_NAME, properties);
+
+        assertEquals(subnet.name(), DEFAULT_SUBNET_NAME);
+        assertEquals(subnet.properties().addressPrefix(), DEFAULT_SUBNET_ADDRESS_SPACE);
+    }
+
+    //mvn -Dtest=SubnetApiLiveTest#getSubnet test
+    @Test(groups = "live", dependsOnMethods = "createSubnet")
+    public void getSubnet() {
+
+        final SubnetApi subnetApi = api.getSubnetApi(subscriptionid, resourcegroup, VIRTUAL_NETWORK_NAME);
+        Subnet subnet = subnetApi.getSubnet(DEFAULT_SUBNET_NAME);
+
+        assertNotNull(subnet.name());
+        assertNotNull(subnet.properties().addressPrefix());
+    }
+
+    //mvn -Dtest=SubnetApiLiveTest#listSubnets test
+    @Test(groups = "live", dependsOnMethods = "getSubnet")
+    public void listSubnets() {
+
+        final SubnetApi subnetApi = api.getSubnetApi(subscriptionid, resourcegroup, VIRTUAL_NETWORK_NAME);
+        List<Subnet> subnets = subnetApi.listSubnets();
+
+        assertTrue(subnets.size() > 0);
+    }
+
+    //mvn -Dtest=SubnetApiLiveTest#deleteSubnet test
+    @Test(groups = "live", dependsOnMethods = "listSubnets", alwaysRun = true)
+    public void deleteSubnet() {
+
+        final SubnetApi subnetApi = api.getSubnetApi(subscriptionid, resourcegroup, VIRTUAL_NETWORK_NAME);
+        subnetApi.deleteSubnet(DEFAULT_SUBNET_NAME);
+    }
+
+}

--- a/azurecompute-arm/src/test/java/org/jclouds/azurecomputearm/features/SubnetApiMockTest.java
+++ b/azurecompute-arm/src/test/java/org/jclouds/azurecomputearm/features/SubnetApiMockTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.azurecomputearm.features;
+
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import org.jclouds.azurecomputearm.domain.Subnet;
+import org.jclouds.azurecomputearm.internal.BaseAzureComputeApiMockTest;
+import org.testng.annotations.Test;
+import java.util.List;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+//mvn -Dtest=SubnetApiMockTest test
+@Test(groups = "unit", testName = "SubnetApiMockTest", singleThreaded = true)
+public class SubnetApiMockTest extends BaseAzureComputeApiMockTest {
+
+    final String subscriptionid = "12345678-2749-4e68-9dcf-e21cda85a132";
+    final String resourcegroup = "myresourcegroup";
+    final String virtualNetwork = "myvirtualnetwork";
+    final String subnetName = "mysubnet";
+    final String apiVersion = "api-version=2015-06-15";
+
+    //mvn -Dtest=SubnetApiMockTest#createSubnet test
+    public void createSubnet() throws InterruptedException {
+
+        server.enqueue(jsonResponse("/createsubnetresponse.json").setResponseCode(200));
+
+        final SubnetApi subnetApi = api.getSubnetApi(subscriptionid, resourcegroup, virtualNetwork);
+
+        //Create properties object
+        Subnet.SubnetProperties properties = Subnet.SubnetProperties.builder().addressPrefix("10.2.0.0/24").build();
+
+        Subnet subnet = subnetApi.createOrUpdateSubnet(subnetName, properties);
+
+        String path = String.format("/subscriptions/%s/resourcegroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/%s?%s", subscriptionid, resourcegroup, virtualNetwork, subnetName, apiVersion);
+        String json = String.format("{ \"properties\":{\"addressPrefix\":\"%s\"}}", "10.2.0.0/24");
+        assertSent(server, "PUT", path, json);
+
+        assertEquals(subnet.name(), subnetName);
+        assertEquals(subnet.properties().addressPrefix(), "10.2.0.0/24");
+    }
+
+    //mvn -Dtest=SubnetApiMockTest#getSubnet test
+    public void getSubnet() throws InterruptedException {
+
+        server.enqueue(jsonResponse("/getonesubnet.json").setResponseCode(200));
+
+        final SubnetApi subnetApi = api.getSubnetApi(subscriptionid, resourcegroup, virtualNetwork);
+
+        Subnet subnet = subnetApi.getSubnet(subnetName);
+
+        String path = String.format("/subscriptions/%s/resourcegroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/%s?%s", subscriptionid, resourcegroup, virtualNetwork, subnetName, apiVersion);
+        assertSent(server, "GET", path);
+
+        assertEquals(subnet.name(), subnetName);
+        assertEquals(subnet.properties().addressPrefix(), "10.2.0.0/24");
+    }
+
+    //mvn -Dtest=SubnetApiMockTest#listSubnets test
+    public void listSubnets() throws InterruptedException {
+
+        server.enqueue(jsonResponse("/listsubnetswithinvirtualnetwork.json").setResponseCode(200));
+
+        final SubnetApi subnetApi = api.getSubnetApi(subscriptionid, resourcegroup, virtualNetwork);
+
+        List<Subnet> subnets = subnetApi.listSubnets();
+
+        String path = String.format("/subscriptions/%s/resourcegroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets?%s", subscriptionid, resourcegroup, virtualNetwork, apiVersion);
+        assertSent(server, "GET", path);
+
+        assertTrue(subnets.size() > 0);
+    }
+
+    //mvn -Dtest=SubnetApiMockTest#deleteSubnet test
+    public void deleteSubnet() throws InterruptedException {
+
+        server.enqueue(response202());
+
+        final SubnetApi subnetApi = api.getSubnetApi(subscriptionid, resourcegroup, virtualNetwork);
+
+        subnetApi.deleteSubnet(subnetName);
+
+        String path = String.format("/subscriptions/%s/resourcegroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/%s?%s", subscriptionid, resourcegroup, virtualNetwork, subnetName, apiVersion);
+        assertSent(server, "DELETE", path);
+    }
+
+    //mvn -Dtest=SubnetApiMockTest#deleteSubnet test
+    public void deleteSubnetResourceDoesNotExist() throws InterruptedException {
+
+        server.enqueue(response204());
+
+        final SubnetApi subnetApi = api.getSubnetApi(subscriptionid, resourcegroup, virtualNetwork);
+
+        subnetApi.deleteSubnet(subnetName);
+
+        String path = String.format("/subscriptions/%s/resourcegroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/%s?%s", subscriptionid, resourcegroup, virtualNetwork, subnetName, apiVersion);
+        RecordedRequest rr = assertSent(server, "DELETE", path);
+    }
+}

--- a/azurecompute-arm/src/test/resources/createsubnet.json
+++ b/azurecompute-arm/src/test/resources/createsubnet.json
@@ -1,0 +1,5 @@
+{
+  "properties":{
+    "addressPrefix":"10.2.0.0/24"
+  }
+}

--- a/azurecompute-arm/src/test/resources/createsubnetresponse.json
+++ b/azurecompute-arm/src/test/resources/createsubnetresponse.json
@@ -1,0 +1,14 @@
+{
+  "name": "mysubnet",
+  "id": "/subscriptions/12345678-2749-4e68-9dcf-e21cda85a132/resourceGroups/azurearmtesting/providers/Microsoft.Network/virtualNetworks/myvirtualnetwork/subnets/mysubnet",
+  "etag": "W/\"b68ab7a3-38d5-4690-a978-20149a6a0994\"",
+  "properties": {
+    "provisioningState": "Succeeded",
+    "addressPrefix": "10.2.0.0/24",
+    "ipConfigurations": [
+      {
+        "id": "/subscriptions/12345678-2749-4e68-9dcf-e21cda85a132/resourceGroups/azurearmtesting/providers/Microsoft.Network/networkInterfaces/myNic/ipConfigurations/myip1"
+      }
+    ]
+  }
+}

--- a/azurecompute-arm/src/test/resources/getonesubnet.json
+++ b/azurecompute-arm/src/test/resources/getonesubnet.json
@@ -1,0 +1,14 @@
+{
+  "name": "mysubnet",
+  "id": "/subscriptions/12345678-2749-4e68-9dcf-e21cda85a132/resourceGroups/azurearmtesting/providers/Microsoft.Network/virtualNetworks/myvirtualnetwork/subnets/mysubnet",
+  "etag": "W/\"bc7e1d77-eec0-4b91-ae80-afc33cf3c867\"",
+  "properties": {
+    "provisioningState": "Succeeded",
+    "addressPrefix": "10.2.0.0/24",
+    "ipConfigurations": [
+      {
+        "id": "/subscriptions/12345678-2749-4e68-9dcf-e21cda85a132/resourceGroups/azurearmtesting/providers/Microsoft.Network/networkInterfaces/myNic/ipConfigurations/myip1"
+      }
+    ]
+  }
+}

--- a/azurecompute-arm/src/test/resources/listsubnetswithinvirtualnetwork.json
+++ b/azurecompute-arm/src/test/resources/listsubnetswithinvirtualnetwork.json
@@ -1,0 +1,18 @@
+{
+  "value": [
+    {
+      "name": "mysubnet",
+      "id": "/subscriptions/12345678-2749-4e68-9dcf-e21cda85a132/resourceGroups/azurearmtesting/providers/Microsoft.Network/virtualNetworks/myvirtualnetwork/subnets/mysubnet",
+      "etag": "W/\"bc7e1d77-eec0-4b91-ae80-afc33cf3c867\"",
+      "properties": {
+        "provisioningState": "Succeeded",
+        "addressPrefix": "10.2.0.0/24",
+        "ipConfigurations": [
+          {
+            "id": "/subscriptions/12345678-2749-4e68-9dcf-e21cda85a132/resourceGroups/azurearmtesting/providers/Microsoft.Network/networkInterfaces/myNic/ipConfigurations/myip1"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
For now live tests expect that Virtual Network "jclouds-virtual-network-live-test" is already created in Azure using address space 10.2.0.0/16.
Make sure you delete the "default" subnet in portal after creating the virtual network.
If not you will receive error message: "Subnet 'jclouds-1' is not valid in virtual network 'jclouds-virtual-network-live-test'."

Live test setup phase has commented code to integrate with Virtual Network API once approved. 

To run live tests:
mvn -Dtest=SubnetApiLiveTest -Dtest.azurecompute-arm.identity="12345678-1a23-1234-1234-123456789123" -Dtest.azurecompute-arm.subscriptionid="12345678-1234-1234-1a23-123456789abc" -Dtest.azurecompute-arm.resourcegroup="armlivetesting" -Dtest.azurecompute-arm.credential="<yourpass>" -Dtest.azurecompute-arm.endpoint="https://management.azure.com/" -Dtest.jclouds.oauth.resource="https://management.azure.com/" -Dtest.oauth.endpoint="https://login.microsoftonline.com/<youraccount>.onmicrosoft.com/oauth2/token" test
