### PR TITLE
Make default templateBuilder.build work

### DIFF
--- a/azurecompute-arm-dev/src/main/java/org/jclouds/azurecompute/arm/compute/functions/ImageReferenceToImage.java
+++ b/azurecompute-arm-dev/src/main/java/org/jclouds/azurecompute/arm/compute/functions/ImageReferenceToImage.java
@@ -59,7 +59,7 @@ public class ImageReferenceToImage implements Function<ImageReference, Image> {
               .name(image.offer())
               .description(image.sku())
               .status(Image.Status.AVAILABLE)
-              .version(image.version())
+              .version(image.sku())
               .id(image.offer() + image.sku() + image.version())
               .providerId(image.publisher());
 
@@ -94,7 +94,7 @@ public class ImageReferenceToImage implements Function<ImageReference, Image> {
                     family(family).
                     is64Bit(true).
                     description(image.sku()).
-                    version(image.version());
+                    version(image.sku());
          }
       };
    }

--- a/azurecompute-arm-dev/src/test/java/org/jclouds/azurecompute/arm/compute/AzureComputeServiceContextLiveTest.java
+++ b/azurecompute-arm-dev/src/test/java/org/jclouds/azurecompute/arm/compute/AzureComputeServiceContextLiveTest.java
@@ -78,6 +78,20 @@ public class AzureComputeServiceContextLiveTest extends BaseComputeServiceContex
 
 
    @Test
+   public void testDefault() throws RunNodesException {
+      final String groupName = String.format("def%s", System.getProperty("user.name"));
+      final TemplateBuilder templateBuilder = view.getComputeService().templateBuilder();
+      final Template template = templateBuilder.build();
+
+      try {
+         Set<? extends NodeMetadata> nodes = view.getComputeService().createNodesInGroup(groupName, 1, template);
+         assertThat(nodes).hasSize(1);
+      } finally {
+         view.getComputeService().destroyNodesMatching(inGroup(groupName));
+      }
+   }
+
+   @Test(dependsOnMethods = "testDefault")
    public void testLinuxNode() throws RunNodesException {
       final String groupName = String.format("ubu%s", System.getProperty("user.name"));
       final TemplateBuilder templateBuilder = view.getComputeService().templateBuilder();


### PR DESCRIPTION
When this is merged, it is possible to clone jclouds-examples and try compute-basics example there. You need to add jClouds snapshot repository and make dependency to azurecompute-arm-dev and then compile example. After that it is possible to run example like this:

java -Dazurecompute-arm.endpoint="https://management.azure.com/subscriptions/<SUBSID>" -Doauth.endpoint="https://login.microsoftonline.com/<TENANT>/oauth2/token" -jar target/compute-basics-jar-with-dependencies.jar azurecompute-arm <IDENTITY> <PASSWORD> myLabel add
